### PR TITLE
feat: Display more information about the index in the search about page

### DIFF
--- a/dgpf1/dgpf1/settings.py
+++ b/dgpf1/dgpf1/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.humanize',
 ]
 
 MIDDLEWARE = [

--- a/dgpf1/dgpf1/urls.py
+++ b/dgpf1/dgpf1/urls.py
@@ -17,10 +17,12 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 from . import views
+import globus_portal_framework.urls
 
 #from django.views.debug import technical_500_response
 
 urlpatterns = [
+    path('<index:index>/about/', views.search_about, name='search-about'),
     path('admin/', admin.site.urls),
     # Provides the basic search portal
     path('', include('globus_portal_framework.urls')),

--- a/dgpf1/dgpf1/views.py
+++ b/dgpf1/dgpf1/views.py
@@ -1,9 +1,13 @@
+import datetime
 from django.conf import settings
 from django.http import FileResponse, HttpRequest, HttpResponse
 from django.views.decorators.cache import cache_control
 from django.views.decorators.http import require_GET
 from django.views import debug
+from django.shortcuts import render
 import sys
+import globus_sdk
+from globus_portal_framework.gsearch import get_index
 
 @require_GET
 @cache_control(max_age=60 * 60 * 24, immutable=True, public=True)  # one day
@@ -13,3 +17,31 @@ def favicon(request: HttpRequest) -> HttpResponse:
 
 def Debug_Details(request, format=None, **kwargs):
     return debug.technical_500_response(request, *sys.exc_info(), status_code=400)
+
+
+@cache_control(max_age=300, immutable=True, public=True)  # five minutes
+def search_about(request: HttpRequest, index: str) -> HttpResponse:
+    index_info = get_index(index)
+    info = globus_sdk.SearchClient().get_index(index_info["uuid"]).data
+    info["creation_date"] = datetime.datetime.fromisoformat(info["creation_date"])
+    # Comment out or change the order of fields below to determine how they are displayed
+    fields = [
+        # {"field_name": "@datatype"}
+        # {"field_name": "@version"},
+        {"field_name": "display_name", "display_name": "Display Name"},
+        {"field_name": "creation_date", "type": "date", "display_name": "Creation Date"},
+        {"field_name": "id"},
+        {"field_name": "is_trial", "display_name": "Trial Index"},
+        {"field_name": "max_size_in_mb", "type": "int", "display_name": "Max Size in MB"},
+        {"field_name": "num_entries", "type": "int", "display_name": "Number of Entries"},
+        {"field_name": "num_subjects", "type": "int", "display_name": "Number of Subjects"},
+        {"field_name": "size_in_mb", "type": "int", "display_name": "Size in MB"},
+        {"field_name": "status"},
+        # {"field_name": "subscription_id"},
+    ]
+    display_fields = fields.copy()
+    for field in display_fields:
+        field["value"] = info[field["field_name"]]
+        field["display_name"] = field.get("display_name") or field["field_name"].capitalize()
+    context = dict(index_info=display_fields)
+    return render(request, "globus-portal-framework/v2/search-about.html", context)

--- a/dgpf1/templates/globus-portal-framework/v2/search-about.html
+++ b/dgpf1/templates/globus-portal-framework/v2/search-about.html
@@ -1,5 +1,5 @@
 {% extends "globus-portal-framework/v2/search-base.html" %}
-{% load is_active index_template is_active %}
+{% load is_active index_template is_active humanize %}
 
 {% block breadcrumb_items %}
 {{block.super}}
@@ -29,11 +29,27 @@
       <a href="https://operations.access-ci.org/online_services/search_pilot" target="_blank">this link</a>.</p>
 
       <p>This pilot uses Globus Search to publish and search HPC-ED pilot training material metadata:
-      <ul>
-        <li>Index Name: <b>{{globus_portal_framework.index_data.name}}</b></li>
-        <li>Index UUID: <b>{{globus_portal_framework.index_data.uuid}}</b></li>
-      <ul>
       </p>
+      <div class="row">
+        <div class="col-md-6">
+          <table class="table table-striped table-bordered">
+            <tbody>
+            {% for item in index_info %}
+            <tr>
+              <td>{{item.display_name}}</td>
+              {% if item.type == "int" %}
+              <td>{{item.value | intcomma }}</td>
+              {% else %}
+              <td>{{item.value }}</td>
+              {% endif %}
+            </tr>
+            {% empty %}
+            <p>No index info is available.</p>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
       {% endblock %} 
     </div>
 {% comment %}


### PR DESCRIPTION
Addresses the following: 

> In the Index about page display all available SDK get_index information

Screenshot:

<img width="680" alt="Screenshot 2024-03-21 at 5 36 01 PM" src="https://github.com/HPC-ED/hpc-ed_django-globus-portal-framework/assets/865553/a3177b6e-0794-47eb-b764-1f917f0cea87">
