### PR TITLE
feat: Replace ugly provider facet ids with nice ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ And assign it to your env with:
 ```
 export APP_CONFIG=local_settings.py
 ```
+
+### Fixtures
+
+Providers data is not populated by default and must be done manually. You can do this with the following: 
+
+```
+python manage.py loaddata initial_providers
+```

--- a/dgpf1/dgpf1/facet_modifiers.py
+++ b/dgpf1/dgpf1/facet_modifiers.py
@@ -1,0 +1,23 @@
+import logging
+from django.conf import settings
+
+log = logging.getLogger(__name__)
+
+
+def __lookup_provider_name(provider_id: str) -> str:
+    for provider in settings.AVAILABLE_PROVIDERS:
+        if provider["id"] == provider_id:
+            return provider["name"]
+    log.warning(f"Provider {provider_id} is unknown and needs to be "
+                "configured in settings.AVAILABLE_PROVIDERS!")
+    return "Other"
+
+
+def lookup_replace_provider_id(facets: dict) -> dict:
+    """Replace all values within the Provider_ID with nice names from
+    the lookup table above"""
+    for facet in facets:
+        if facet["field_name"] == "Provider_ID":
+            for bucket in facet["buckets"]:
+                bucket["value"] = __lookup_provider_name(bucket["value"])
+    return facets

--- a/dgpf1/dgpf1/facet_modifiers.py
+++ b/dgpf1/dgpf1/facet_modifiers.py
@@ -1,16 +1,8 @@
 import logging
 from django.conf import settings
+from provider.models import Provider
 
 log = logging.getLogger(__name__)
-
-
-def __lookup_provider_name(provider_id: str) -> str:
-    for provider in settings.AVAILABLE_PROVIDERS:
-        if provider["id"] == provider_id:
-            return provider["name"]
-    log.warning(f"Provider {provider_id} is unknown and needs to be "
-                "configured in settings.AVAILABLE_PROVIDERS!")
-    return "Other"
 
 
 def lookup_replace_provider_id(facets: dict) -> dict:
@@ -19,5 +11,10 @@ def lookup_replace_provider_id(facets: dict) -> dict:
     for facet in facets:
         if facet["field_name"] == "Provider_ID":
             for bucket in facet["buckets"]:
-                bucket["value"] = __lookup_provider_name(bucket["value"])
+                try:
+                    bucket["value"] = Provider.objects.get(Provider_ID=bucket["value"]).Provider_Name
+                except Provider.DoesNotExist:
+                    log.warning(f"Provider {bucket['value']} is unknown and needs to be "
+                                "added to the database!")
+                    bucket["value"] = "Other"
     return facets

--- a/dgpf1/dgpf1/settings.py
+++ b/dgpf1/dgpf1/settings.py
@@ -252,23 +252,4 @@ SEARCH_INDEXES = {
     },
 }
 
-AVAILABLE_PROVIDERS = [
-    {
-        "name": "Linked In",
-        "id": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:897",
-    },
-    {
-        "name": "Lynda",
-        "id": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:896",
-    },
-    {
-        "name": "Cornell University",
-        "id": "urn:ogf:glue2.access-ci.org:organization:cac.cornell.edu",
-    },
-    {
-        "name": "SC Conference Series",
-        "id": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:352",
-    }
-]
-
 PROJECT_TITLE = 'Search Pilot'

--- a/dgpf1/dgpf1/settings.py
+++ b/dgpf1/dgpf1/settings.py
@@ -132,6 +132,21 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'stream': {'level': 'DEBUG', 'class': 'logging.StreamHandler'},
+        'null': {'level': 'DEBUG', 'class': 'logging.NullHandler'},
+    },
+    'loggers': {
+        'django': {'handlers': ['stream'], 'level': 'INFO'},
+        'django.db.backends': {'handlers': ['stream'], 'level': 'WARNING'},
+        'globus_portal_framework': {'handlers': ['stream'], 'level': 'INFO'},
+        'dgpf1': {'handlers': ['stream'], 'level': 'INFO', 'propagate': True},
+    },
+}
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/
@@ -207,7 +222,11 @@ SEARCH_INDEXES = {
             {'name': 'License', 'field_name': 'License' },
             {'name': 'URL Type', 'field_name': 'Resource_URL_Type' },
             {'name': 'Provider ID', 'field_name': 'Provider_ID' },
-        ]
+        ],
+        'facet_modifiers': [
+            'globus_portal_framework.modifiers.facets.drop_empty',
+            'dgpf1.facet_modifiers.lookup_replace_provider_id',
+        ],
     },
     'hpc-ed-v1-match-all': {
         'name': 'HPC Training Material (HPC-ED) - Alpha catalog v1 (match all)',
@@ -225,8 +244,31 @@ SEARCH_INDEXES = {
             {'name': 'License', 'field_name': 'License' },
             {'name': 'URL Type', 'field_name': 'Resource_URL_Type' },
             {'name': 'Provider ID', 'field_name': 'Provider_ID' },
-        ]
+        ],
+        'facet_modifiers': [
+            'globus_portal_framework.modifiers.facets.drop_empty',
+            'dgpf1.facet_modifiers.lookup_replace_provider_id',
+        ],
     },
 }
+
+AVAILABLE_PROVIDERS = [
+    {
+        "name": "Linked In",
+        "id": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:897",
+    },
+    {
+        "name": "Lynda",
+        "id": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:896",
+    },
+    {
+        "name": "Cornell University",
+        "id": "urn:ogf:glue2.access-ci.org:organization:cac.cornell.edu",
+    },
+    {
+        "name": "SC Conference Series",
+        "id": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:352",
+    }
+]
 
 PROJECT_TITLE = 'Search Pilot'

--- a/dgpf1/dgpf1/tests.py
+++ b/dgpf1/dgpf1/tests.py
@@ -1,0 +1,42 @@
+"""
+* Requires library pytest-django (pip install pytest-django)
+* Also requires an env for the settings file: DJANGO_SETTINGS_MODULE=dgpf1.settings
+    This should probably be configured in setup.cfg, or Pipfile if supported
+
+Run with:
+pytest dgpf1/tests.py
+
+"""
+import pytest
+from django.core.management import call_command
+from dgpf1 import facet_modifiers
+
+# Populate the database for this entire test session, with initial provider data.
+@pytest.fixture(scope='session')
+def django_db_setup(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        call_command('loaddata', 'initial_providers.json')
+
+
+@pytest.mark.django_db
+def test_facet_modifiers_lookup_known_provider_id():
+    facets = [
+        {
+            "field_name": "Provider_ID",
+            "buckets": [{"value": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:897"}]
+        }
+    ]
+    updated_facets = facet_modifiers.lookup_replace_provider_id(facets)
+    assert updated_facets[0]["buckets"][0]["value"] == "Linked In"
+
+
+@pytest.mark.django_db
+def test_facet_modifiers_lookup_unknown_provider_id():
+    facets = [
+        {
+            "field_name": "Provider_ID",
+            "buckets": [{"value": "does_not_exist"}]
+        }
+    ]
+    updated_facets = facet_modifiers.lookup_replace_provider_id(facets)
+    assert updated_facets[0]["buckets"][0]["value"] == "Other"

--- a/dgpf1/provider/fixtures/initial_providers.json
+++ b/dgpf1/provider/fixtures/initial_providers.json
@@ -1,0 +1,34 @@
+[
+    {
+      "model": "provider.provider",
+      "pk": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:352",
+      "fields": {
+        "Provider_Short_Name": "SC",
+        "Provider_Name": "SC Conference Series"
+      }
+    },
+    {
+      "model": "provider.provider",
+      "pk": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:896",
+      "fields": {
+        "Provider_Short_Name": "Lynda",
+        "Provider_Name": "Lynda"
+      }
+    },
+    {
+      "model": "provider.provider",
+      "pk": "urn:ogf.org:glue2:access-ci.org:resource:cider:infrastructure.organizations:897",
+      "fields": {
+        "Provider_Short_Name": "LinkedIn",
+        "Provider_Name": "Linked In"
+      }
+    },
+    {
+      "model": "provider.provider",
+      "pk": "urn:ogf:glue2.access-ci.org:organization:cac.cornell.edu",
+      "fields": {
+        "Provider_Short_Name": "Cornell Univ.",
+        "Provider_Name": "Cornell University"
+      }
+    }
+    ]


### PR DESCRIPTION
For item below:
> In the Search page Provider ID facet, display a Provider Name from a Django lookup table, rather than the Provider ID

The changes below result in the following: 

<img width="437" alt="Screenshot 2024-03-21 at 4 44 33 PM" src="https://github.com/HPC-ED/hpc-ed_django-globus-portal-framework/assets/865553/c8044bff-90e9-4e6d-ae79-a9446b7ba1ed">

In the future, it would be nice to include this name with other search result data, so we didn't need the lookup table.
