### PR TITLE
Detail page changes

### DIFF
--- a/dgpf1/dgpf1/fields.py
+++ b/dgpf1/dgpf1/fields.py
@@ -1,2 +1,10 @@
-def Title(result):
-    return result.all[0]['Title']
+
+
+def title(result):
+    """Return the title for this result, overriding the base template default of 'Result'"""
+    return result[0]['Title']
+
+
+def general_info(result):
+    """Return all basic information in the first gmeta entry"""
+    return result[0]

--- a/dgpf1/dgpf1/fields.py
+++ b/dgpf1/dgpf1/fields.py
@@ -1,4 +1,4 @@
-
+import datetime
 
 def title(result):
     """Return the title for this result, overriding the base template default of 'Result'"""
@@ -8,3 +8,42 @@ def title(result):
 def general_info(result):
     """Return all basic information in the first gmeta entry"""
     return result[0]
+
+
+def detail_result_display_fields(result):
+    """
+    Return all fields in a consistent order, and attach any field specific info
+    like if a field is a number or needs special rendering.
+    """
+    possible_date_fields = ["Version_Date", "Start_Datetime"]
+    info = general_info(result)
+    known_fields = [
+        {"field_name": "Title"},
+        {"field_name": "Abstract"},
+        {"field_name": "Authors"},
+        {"field_name": "Expertise_Level"},
+        {"field_name": "Learning_Outcome"},
+        {"field_name": "Learning_Resource_Type"},
+        {"field_name": "Target_Group"},
+        {"field_name": "Keywords"},
+    ]
+    known_field_names = [fl["field_name"] for fl in known_fields]
+    other_fields = [{"field_name": f} for f in info
+                    if f not in known_field_names]
+    display_fields = known_fields + other_fields + [
+        {"field_name": "Provider_ID", "display_name": "Provider ID"},
+        {"field_name": "Rating"},
+    ]
+    # Populate values from info
+    for item in display_fields:
+        item["display_name"] = item.get("display_name", item["field_name"].replace("_", " "))
+        item["value"] = info.get(item["field_name"])
+        if isinstance(item["value"], list):
+            item["value"] = ", ".join(item["value"])
+        if item["field_name"] in possible_date_fields:
+            try:
+                item["value"] = datetime.datetime.fromisoformat(item["value"].replace("Z", ""))
+            except Exception:
+                # If the date cannot be parsed, just leave it.
+                pass
+    return display_fields

--- a/dgpf1/dgpf1/settings.py
+++ b/dgpf1/dgpf1/settings.py
@@ -19,7 +19,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 import json
 import os
 import sys
-from dgpf1.fields import title, general_info
+from dgpf1.fields import title, general_info, detail_result_display_fields
 #import pdb
 #pdb.set_trace()
 
@@ -211,6 +211,7 @@ SEARCH_INDEXES = {
         'fields': [
             ('title', title),
             ('general_info', general_info),
+            ('detail_result_display_fields', detail_result_display_fields),
         ],
     },
     'hpc-ed-v1-match-all': {
@@ -233,6 +234,7 @@ SEARCH_INDEXES = {
         'fields': [
             ('title', title),
             ('general_info', general_info),
+            ('detail_result_display_fields', detail_result_display_fields),
         ],
     },
 }

--- a/dgpf1/dgpf1/settings.py
+++ b/dgpf1/dgpf1/settings.py
@@ -19,7 +19,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 import json
 import os
 import sys
-
+from dgpf1.fields import title, general_info
 #import pdb
 #pdb.set_trace()
 
@@ -207,7 +207,11 @@ SEARCH_INDEXES = {
             {'name': 'License', 'field_name': 'License' },
             {'name': 'URL Type', 'field_name': 'Resource_URL_Type' },
             {'name': 'Provider ID', 'field_name': 'Provider_ID' },
-        ]
+        ],
+        'fields': [
+            ('title', title),
+            ('general_info', general_info),
+        ],
     },
     'hpc-ed-v1-match-all': {
         'name': 'HPC Training Material (HPC-ED) - Alpha catalog v1 (match all)',
@@ -225,7 +229,11 @@ SEARCH_INDEXES = {
             {'name': 'License', 'field_name': 'License' },
             {'name': 'URL Type', 'field_name': 'Resource_URL_Type' },
             {'name': 'Provider ID', 'field_name': 'Provider_ID' },
-        ]
+        ],
+        'fields': [
+            ('title', title),
+            ('general_info', general_info),
+        ],
     },
 }
 

--- a/dgpf1/templates/globus-portal-framework/v2/components/detail-general-metadata.html
+++ b/dgpf1/templates/globus-portal-framework/v2/components/detail-general-metadata.html
@@ -1,16 +1,12 @@
 <table class="table table-striped table-bordered">
   <tbody>
   {% block detail_general_metadata %}
-  {% for key, value in project_metadata.items %}
+  {% for key, value in general_info.items %}
   <tr>
     <td>{{key}}</td>
     <td>{{value}}</td>
   </tr>
   {% endfor %}
-  <tr>
-    <td><b>subject</b></td>
-    <td>{{ subject }}</td>
-  </tr>
   {% endblock %}
   </tbody>
 </table>

--- a/dgpf1/templates/globus-portal-framework/v2/components/detail-general-metadata.html
+++ b/dgpf1/templates/globus-portal-framework/v2/components/detail-general-metadata.html
@@ -1,10 +1,10 @@
 <table class="table table-striped table-bordered">
   <tbody>
   {% block detail_general_metadata %}
-  {% for key, value in general_info.items %}
+  {% for item in detail_result_display_fields %}
   <tr>
-    <td>{{key}}</td>
-    <td>{{value}}</td>
+    <td>{{item.display_name}}</td>
+    <td>{{item.value}}</td>
   </tr>
   {% endfor %}
   {% endblock %}

--- a/dgpf1/templates/globus-portal-framework/v2/components/detail-globus-search-metadata.html
+++ b/dgpf1/templates/globus-portal-framework/v2/components/detail-globus-search-metadata.html
@@ -1,0 +1,9 @@
+
+<table class="table table-striped table-bordered">
+    <tbody>
+    <tr>
+      <td><b>subject</b></td>
+      <td>{{ subject }}</td>
+    </tr>
+    </tbody>
+  </table>

--- a/dgpf1/templates/globus-portal-framework/v2/components/detail-nav.html
+++ b/dgpf1/templates/globus-portal-framework/v2/components/detail-nav.html
@@ -50,12 +50,11 @@ Requires the following fields:
                 class="btn btn-primary nav-link active" data-toggle="collapse" href="#collapseExample"
                 target="_blank" role="button" aria-expanded="false" aria-controls="collapseExample"
                 {% else %}
-                class="btn btn-light nav-link disabled" href="#"
+                class="btn btn-light nav-link" href="{{general_info.URL}}" target="_blank"
                 {% endif %}
         >
           <i class="fas fa-link"></i>
 	  Follow Training URL
-	  {{ project_metadata }}
         </a>
         {% endblock %}
       </li>

--- a/dgpf1/templates/globus-portal-framework/v2/detail-overview.html
+++ b/dgpf1/templates/globus-portal-framework/v2/detail-overview.html
@@ -14,32 +14,12 @@
   <div class="col-md-12">
 
         {% block detail_search_content %}
-	{% comment %}
-        {% if result.dc or result.files or result.project_metadata  %}
-        <h3 class="text-center mb-5">General Info</h3>
-        {% with all|first as result %}
-        <div class="row">
-          <div class="col-md-6">
-            {% include 'globus-portal-framework/v2/components/detail-dc-metadata.html' %}
-          </div>
-          <div class="col-md-6">
-            {% include 'globus-portal-framework/v2/components/detail-general-metadata.html' %}
-          </div>
-        </div>
-        {% endwith %}
-
-        {% else %}
-	{% endcomment %}
-
         <h3 class="text-center mb-5">Training Material Metadata</h3>
-        {% with all|first as project_metadata %}
         {% include 'globus-portal-framework/v2/components/detail-general-metadata.html' %}
-        {% endwith %}
-	{% comment %}
-        {% endif %}
-	{% endcomment %}
-        {% endblock %}
 
+        <h3 class="text-center my-5">Globus Search Metadata</h3>
+        {% include 'globus-portal-framework/v2/components/detail-globus-search-metadata.html' %}
+        {% endblock %}
 
   </div>
 </div>


### PR DESCRIPTION
Addresses the following: 

- [x] In the Result Details page make the “Follow Training URL” link in the top right and the URL field value both open the link target in a new tab

- [x] In the Result Details page order the HPC-ED field in a pre-defined custom order (can be hardcoded in the source)

- [x] In the Result Details page create a separate fields block at the bottom of the page where all the Globus Search metadata fields, like subject and entry_id are listed separately from the HPC-ED fields listed earlier
    * **Special Note** Globus Portal Framework currently doesn't support returning entry ids from result info, due to how result formats previously worked in Globus Search. It's doable, just a bit more work. Let me know if that's preferred.


@jpnavarro I wasn't sure what the "HPC-ED field" was in item 2 or how to order it, can you clarify that please? 

Screenshots: 

<img width="1244" alt="Screenshot 2024-03-21 at 5 39 49 PM" src="https://github.com/HPC-ED/hpc-ed_django-globus-portal-framework/assets/865553/4b40a3e4-4be0-41c9-aff7-7031d0b86407">
<img width="1308" alt="Screenshot 2024-03-21 at 5 40 16 PM" src="https://github.com/HPC-ED/hpc-ed_django-globus-portal-framework/assets/865553/f61d616a-3131-4a88-a376-7de5ea43c716">