### PR TITLE
fix: Provider id facet-filters resulting in zero results when clicked

### DIFF
--- a/dgpf1/dgpf1/facet_modifiers.py
+++ b/dgpf1/dgpf1/facet_modifiers.py
@@ -12,9 +12,9 @@ def lookup_replace_provider_id(facets: dict) -> dict:
         if facet["field_name"] == "Provider_ID":
             for bucket in facet["buckets"]:
                 try:
-                    bucket["value"] = Provider.objects.get(Provider_ID=bucket["value"]).Provider_Name
+                    bucket["custom_display_value"] = Provider.objects.get(Provider_ID=bucket["value"]).Provider_Name
                 except Provider.DoesNotExist:
                     log.warning(f"Provider {bucket['value']} is unknown and needs to be "
                                 "added to the database!")
-                    bucket["value"] = "Other"
+                    bucket["custom_display_value"] = "Other"
     return facets

--- a/dgpf1/dgpf1/tests.py
+++ b/dgpf1/dgpf1/tests.py
@@ -27,7 +27,7 @@ def test_facet_modifiers_lookup_known_provider_id():
         }
     ]
     updated_facets = facet_modifiers.lookup_replace_provider_id(facets)
-    assert updated_facets[0]["buckets"][0]["value"] == "Linked In"
+    assert updated_facets[0]["buckets"][0]["custom_display_value"] == "Linked In"
 
 
 @pytest.mark.django_db
@@ -39,4 +39,4 @@ def test_facet_modifiers_lookup_unknown_provider_id():
         }
     ]
     updated_facets = facet_modifiers.lookup_replace_provider_id(facets)
-    assert updated_facets[0]["buckets"][0]["value"] == "Other"
+    assert updated_facets[0]["buckets"][0]["custom_display_value"] == "Other"

--- a/dgpf1/templates/globus-portal-framework/v2/components/search-facets.html
+++ b/dgpf1/templates/globus-portal-framework/v2/components/search-facets.html
@@ -1,0 +1,20 @@
+{% extends 'globus-portal-framework/v2/components/search-facets.html' %}
+{% comment %}
+
+See https://github.com/globus/django-globus-portal-framework/blob/main/globus_portal_framework/templates/globus-portal-framework/v2/components/search-facets.html
+
+{% endcomment %}
+
+{% block facet_value %}
+
+{% if field.custom_display_value %}
+
+{{field.custom_display_value}}
+
+{% else %}
+
+{{ block.super }}
+
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Provider id facets incorrectly replaced the filter value and caused the search filter to be for something that didn't exist, causing searches with these filters to return zero results.

Facet values now use the original proper values, while custom_display_value is now used to change how facets look.